### PR TITLE
Update image that no longer exists and be consistent with other image sources

### DIFF
--- a/deploy/csi-moosefs.yaml
+++ b/deploy/csi-moosefs.yaml
@@ -300,7 +300,7 @@ spec:
       containers:
         # registrar
         - name: driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v2.1.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.1.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"


### PR DESCRIPTION
Recently deployed moosefs-csi to my k3s stack and identified problem with this image reference that no longer exists (quay currently hosts v1.3.0).  Updated to match other image sources for reliability.