### PR TITLE
feature: add volume prefix for multi-storage-class provisioning

### DIFF
--- a/driver/controller.go
+++ b/driver/controller.go
@@ -19,6 +19,7 @@ package driver
 import (
 	"context"
 	"fmt"
+	"io/fs"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
@@ -97,7 +98,16 @@ func (cs *ControllerService) CreateVolume(ctx context.Context, req *csi.CreateVo
 		return nil, status.Error(codes.InvalidArgument, "CreateVolume: VolumeContentSource not supported")
 	}
 
-	volumeId := req.Name
+	volumePrefix, ok := req.Parameters["volumePrefix"]
+	if !ok {
+		volumePrefix = ""
+	}
+
+	volumeId := fmt.Sprintf("%s%s", volumePrefix, req.Name)
+	if !fs.ValidPath(volumeId) {
+		return nil, status.Error(codes.InvalidArgument, "CreateVolume: combined volumeId with volumePrefix is not a valid path")
+	}
+
 	exists, err := cs.ctlMount.VolumeExist(volumeId)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
@@ -121,9 +131,6 @@ func (cs *ControllerService) CreateVolume(ctx context.Context, req *csi.CreateVo
 			log.Warningf("CreateVolume - requested %d bytes, got %d", requestedQuota, acquiredSize)
 		}
 	}
-	if len(req.Parameters) != 0 {
-		return nil, status.Errorf(codes.Internal, "CreateVolume: Plugin parameters are not supported")
-	}
 	/*
 		volumeContext := req.GetParameters()
 		if volumeContext == nil {
@@ -144,7 +151,7 @@ func (cs *ControllerService) CreateVolume(ctx context.Context, req *csi.CreateVo
 	*/
 	resp := &csi.CreateVolumeResponse{
 		Volume: &csi.Volume{
-			VolumeId:      req.GetName(),
+			VolumeId:      volumeId,
 			CapacityBytes: acquiredSize,
 		},
 	}


### PR DESCRIPTION
This PR introduces a `volumePrefix` parameter to the MooseFS CSI Driver that allows users to provision different Kubernetes storage class volumes to different path prefixes within MooseFS. By configuring distinct `volumePrefix` values for different StorageClass objects, users can then use the MooseFS tool `mfssclass set` on subdirectories to map specific k8s storage classes directly to different MooseFS storage classes, enabling fine-grained storage tiering and management.

Example:

```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: moosefs-2cp
provisioner: csi.moosefs.com
parameters:
  volumePrefix: "2CP/"
```

```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: moosefs-3cp
provisioner: csi.moosefs.com
parameters:
  volumePrefix: "3CP/"
```

And set correspondingly in moosefs:
```bash
$ mfssclass set 2CP /pv_data/volumes/2CP
$ mfssclass set 3CP /pv_data/volumes/3CP
```